### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,11 +7,11 @@ It must not be used as standalone crypto library.
 
 You can find more information in the `documentation`_.
 
-.. image:: https://pypip.in/version/flextls/badge.svg
+.. image:: https://img.shields.io/pypi/v/flextls.svg
     :target: https://pypi.python.org/pypi/flextls/
     :alt: Latest Version
 
-.. image:: https://pypip.in/license/flextls/badge.svg
+.. image:: https://img.shields.io/pypi/l/flextls.svg
     :target: https://pypi.python.org/pypi/flextls/
     :alt: License
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20flextls))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `flextls`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.